### PR TITLE
Added --ld-library-path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@
   * check_adaptec_raid plugin
   * arcconf
   * sudoers entry for user nagios and arcconf
-    (example: nagios ALL=(root) NOPASSWD:/sbin/arcconf)
+    (example: nagios ALL=(root) NOPASSWD:/sbin/arcconf
+    If --ld-library-path is used, then the SETENV: flag must be added)
 * NRPE (optional): command definition
 * On the Icinga-server:
   * command definition

--- a/check_adaptec_raid
+++ b/check_adaptec_raid
@@ -79,6 +79,9 @@ sub displayUsage {
 	print "  [ -p <path> | --path <path>]
     Specifies the path to arcconf, per default uses the tool 'which' to get 
     the arcconf path.\n";
+	print "  [ --ld-library-path <path>]
+    Sets the LD_LIBRARY_PATH before running arcconf, this requires setting
+    the SETENV: flag in the sudoers entry";
 	print "  [ -z <0/1> | --ZMM <0/1> ]
     Check if a ZMM is present unless '-z 0' is defined. This ensures that for a
     given controller a ZMM must be present per default.\n";
@@ -845,7 +848,7 @@ sub getPerfString{
 }
 
 MAIN: {
-	my ($arcconf, $sudo, $noSudo, $version, $exitCode);
+	my ($arcconf, $sudo, $noSudo, $ldLibraryPath, $version, $exitCode);
 	# Create default sensor arrays and push them to status level
 	my @statusLevel_a ;
 	my $status_str = 'OK';
@@ -880,6 +883,7 @@ MAIN: {
 		'p|path=s' => \$arcconf,
 		'z|ZMM=i' => \$zmm,
 		'nosudo' => \$noSudo,
+		'ld-library-path=s' => \$ldLibraryPath,
 	))){
 		print $NAME . " Version: " . $VERSION ."\n";
 		displayUsage();
@@ -909,7 +913,12 @@ MAIN: {
 				exit(STATE_UNKNOWN);
 			}
 			if($> != 0){
-				$arcconf = $sudo.' '.$arcconf;
+				if(!defined($ldLibraryPath)){
+					$arcconf = $sudo.' '.$arcconf;
+				}
+				else{
+					$arcconf = $sudo.' LD_LIBRARY_PATH='.$ldLibraryPath.' '.$arcconf;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If you installed /usr/StorMan/arcconf and /usr/StorMan/libstdc++.so.5 manually (without using an installation package) you may have to modify  /etc/ld.so.conf.d/ and run ldconfig in order to have /usr/StorMan in the default LD_LIBRARY_PATH.
However if you ant to have as less as possible impact in your system (or have other reasons not to have libstdc++.so.5 in a system-wide path), you can run arcconf in a more "isolated" manner.
`check_adaptec_raid -p /usr/StorMan/arcconf --ld-library-path /usr/StorMan`
This requires a change in the sudoers file:
`mon ALL=(root) NOPASSWD: SETENV: /usr/StorMan/arcconf`

Inside the plugin, arcconf is then called like this:
`sudo LD_LIBRARY_PATH=/usr/StorMan /usr/StorMan/arcconf`